### PR TITLE
fix misleading info

### DIFF
--- a/eva_clip/model.py
+++ b/eva_clip/model.py
@@ -25,7 +25,7 @@ try:
     from apex.normalization import FusedLayerNorm
 except:
     FusedLayerNorm = LayerNorm
-    print("Please 'pip install apex'")
+    print("Please install apex")
 
 try:
     import xformers.ops as xops


### PR DESCRIPTION
If you run `pip install apex`, you’ll end up wasting your morning like I did.

It’s not the same as the [NVIDIA apex](https://github.com/NVIDIA/apex). Instead, it installs this [Pyramid toolkit package](https://pypi.org/project/apex/) that adds Velruse, Flash Messages, CSRF, ReCaptcha, and Sessions.

Since the package's homepage is gone, it’s not on GitHub, and it hasn’t been maintained since 2013, I had to be extra cautious. Due to recent security concerns, I meticulously checked the source code and reviewed all its dependencies. I then uninstalled everything to make sure no harmful code was left behind.

That’s how my morning went.