### PR TITLE
ignore `onnxruntime-gpu` for macOS and for arm64 CPUs

### DIFF
--- a/pulid.py
+++ b/pulid.py
@@ -228,7 +228,7 @@ class PulidInsightFaceLoader:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "provider": (["CPU", "CUDA", "ROCM"], ),
+                "provider": (["CPU", "CUDA", "ROCM", "CoreML"], ),
             },
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 facexlib
 insightface
 onnxruntime
-onnxruntime-gpu
+onnxruntime-gpu; sys_platform != 'darwin' and platform_machine == 'x86_64'
 ftfy
 timm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ facexlib
 insightface
 onnxruntime
 onnxruntime-gpu; sys_platform != 'darwin' and platform_machine == 'x86_64'
+onnxruntime-silicon; sys_platform == 'darwin'
 ftfy
 timm


### PR DESCRIPTION
Good day.

There are no binary wheels for macOS for this package and there won't be any, because the package won't work on mac.

There are no binary wheels for linux aarch64(arm64) either, so they are also added to ignore.

I hope this little pull request will be useful.