### PR TITLE
Fixed face selection by removing reverse=True in apply_pulid function

### DIFF
--- a/pulid.py
+++ b/pulid.py
@@ -354,7 +354,7 @@ class ApplyPulid:
                 face_analysis.det_model.input_size = size
                 face = face_analysis.get(image[i])
                 if face:
-                    face = sorted(face, key=lambda x: (x.bbox[2] - x.bbox[0]) * (x.bbox[3] - x.bbox[1]), reverse=True)[-1]
+                    face = sorted(face, key=lambda x: (x.bbox[2] - x.bbox[0]) * (x.bbox[3] - x.bbox[1]))[-1]
                     iface_embeds = torch.from_numpy(face.embedding).unsqueeze(0).to(device, dtype=dtype)
                     break
             else:


### PR DESCRIPTION
Hi,

I hope you’re doing well. I noticed a small issue in the apply_pulid function within the ApplyPulid node. The function aims to select the detected face with the largest area to get the best embeddings. However, the current implementation seems to have a minor bug.

In the line:
`face = sorted(face, key=lambda x: (x.bbox[2] - x.bbox[0]) * (x.bbox[3] - x.bbox[1]), reverse=True)[-1]`

The reverse=True parameter sorts the faces in descending order by area, but the [-1] index selects the smallest area face instead of the largest. To fix this, the reverse=True should be removed, so the largest area face is selected correctly.

Proposed fix:
`face = sorted(face, key=lambda x: (x.bbox[2] - x.bbox[0]) * (x.bbox[3] - x.bbox[1]))[-1]`

Thank you for your attention to this matter.